### PR TITLE
Add link to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ Created by **[bukkbeek](https://bukkbeek.github.io/)** - an independent game dev
 ### 🎮 Get Pixel Renderer
 [![GitHub](https://img.shields.io/badge/GitHub-Free%20%26%20Open%20Source-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/bukkbeek/GodotPixelRenderer)
 [![Itch.io](https://img.shields.io/badge/Itch.io-Compiled%20Version-FA5C5C?style=for-the-badge&logo=itchdotio&logoColor=white)](https://bukkbeek.itch.io/pixel-renderer)
+[![AUR](https://img.shields.io/aur/version/godot-pixel-renderer-git?style=for-the-badge&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/godot-pixel-renderer-git)
 
 - **🆓 [GitHub](https://github.com/bukkbeek/GodotPixelRenderer)**: Free and open source
 - **💰 [Itch.io](https://bukkbeek.itch.io/pixel-renderer)**: Compiled version (support the developer!)
+- **🆓 [AUR](https://aur.archlinux.org/packages/godot-pixel-renderer-git)**: Free and open source, for Arch Linux users
 
 
 ## ✨ Features


### PR DESCRIPTION
I made an Arch User Repository (AUR) package for GodotPixelRenderer called [`godot-pixel-renderer-git`](http://aur.archlinux.org/packages/godot-pixel-renderer-git) (which builds from source on the user's machine), and added it to the readme as an installation method :)